### PR TITLE
TX quality: µs timing + Farnsworth/weighting + API + roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,6 @@ Das System kann nun nicht nur senden, sondern auch empfangen und selbstständig 
 *   **FIR-Filtering**: Integrierte Signalverarbeitung für saubere CW-Töne und besseres SNR.
 *   **QSO Bot**: Eine State-Machine, die CQ ruft, auf Antworten wartet, Rapporte (599) austauscht und das QSO loggt.
 
-## TX Signalqualität
-Der Senderpfad ist so aufgebaut, dass das IO-Board das **deterministische** CW-Timing macht und der Pi nur Parameter/Jobs setzt.
-
-Aktuell (Backend/IO-Board Interface):
-- Konfigurierbares PTT-Pre-Delay und Tail-Delay pro Job (`ptt_lead_ms`, `ptt_tail_ms`) zur sauberen TX/RX-Umschaltung.
-- Konsistente TX-Job-Steuerung über `CWJobManager` (FastAPI -> IO-Board Register).
-
-Geplant (Firmware-seitig, siehe Roadmap):
-- Envelope shaping (Rise/Fall) zur Reduktion von Key-Clicks.
-- Phasenkohärentes Keying (Amplitude rammen, Carrier/NCO läuft durch).
-- Definierte TX-Enable-Settling-Zeiten (TX enable -> settle -> keying).
-
 ## Repository Struktur
 
 ```
@@ -62,20 +50,6 @@ Geplant (Firmware-seitig, siehe Roadmap):
     *   Standardmäßig ist nun der interne Streamer aktiviert (`USE_INTERNAL_STREAMER=True`).
 5.  **WebUI öffnen**: siehe `pi/webui/README.md`.
 
-## API (TX)
-
-`POST /cw/send`
-
-Beispiel:
-```json
-{
-  "text": "CQ CQ SOTA DE ...",
-  "wpm": 20,
-  "ptt_lead_ms": 80,
-  "ptt_tail_ms": 120
-}
-```
-
 ## Feature Roadmap
 
 ### Phase 1: Basics (Abgeschlossen)
@@ -95,12 +69,12 @@ Beispiel:
 - [ ] **SOTA CSV Export**: Download des Logs direkt über das Web-UI.
 - [ ] **Erweiterte Bot-Logik**: Umgang mit "QRL?", "QRS" und RBN-Spotting.
 
-### Phase 4: TX Signalqualität (Neu)
-- [x] API/Backend: PTT lead/tail pro TX-Job (`ptt_lead_ms`, `ptt_tail_ms`).
-- [ ] Firmware: CW Envelope Shaping (konfigurierbare Rise/Fall-Rampen) zur Reduktion von Key-Clicks.
-- [ ] Firmware: Phase-coherent CW (nur Amplitude rammen; Carrier läuft durch), um Chirp/Spurs zu minimieren.
-- [ ] Firmware: TX/RX Sequencing (TX-Enable -> settle -> keying; ramp-down -> settle -> RX).
-- [ ] Mess-/Verifikationsmodus: reproduzierbare Bewertung der Aussendungsqualität (Timing-Logs/Parameter).
+### Phase 4: TX Quality (Neu)
+- [x] **Deterministisches CW Timing (Firmware)**: Umstellung auf µs-basierte Delays (reduzierter Drift/Jitter im Element-Timing).
+- [x] **Farnsworth Spacing**: Element-Speed per WPM, aber vergrößerte Character/Word-Gaps über `farnsworth_wpm`.
+- [x] **Keying Weighting**: Konfigurierbare Dit/Dah-Keydown-Skalierung über `weight_pct` (50 = nominal).
+- [ ] **Envelope Shaping / Key Click Reduction**: Benötigt HL2-interne TX-Amplitudensteuerung oder externe Envelope-Hardware (nicht nur GPIO KEY on/off).
+- [ ] **QSK / Semi-BK Optimierung**: PTT/KEY Lead/Tail dynamisch (bandabhängig) und optional RX-TX „fast switch“.
 
 ## Lizenz / Third-Party
 

--- a/firmware/pico_cw_keyer/src/cw_morse.c
+++ b/firmware/pico_cw_keyer/src/cw_morse.c
@@ -1,19 +1,64 @@
 #include "cw_morse.h"
 
+static inline uint32_t clamp_u32(uint32_t v, uint32_t lo, uint32_t hi) {
+  if (v < lo) return lo;
+  if (v > hi) return hi;
+  return v;
+}
+
+static inline uint16_t clamp_u16(uint16_t v, uint16_t lo, uint16_t hi) {
+  if (v < lo) return lo;
+  if (v > hi) return hi;
+  return v;
+}
+
 // PARIS standard: dit length = 1200 / WPM ms
 cw_timing_t cw_timing_from_wpm(uint16_t wpm) {
   if (wpm < 5) wpm = 5;
   if (wpm > 60) wpm = 60;
 
-  uint32_t dit = 1200u / (uint32_t)wpm;
+  uint32_t dit_ms = 1200u / (uint32_t)wpm;
+  uint32_t dit_us = dit_ms * 1000u;
+
   cw_timing_t t = {
-    .dit_ms = dit,
-    .dah_ms = 3u * dit,
-    .intra_symbol_ms = dit,
-    .inter_char_ms = 3u * dit,
-    .inter_word_ms = 7u * dit,
+    .dit_us = dit_us,
+    .dah_us = 3u * dit_us,
+    .intra_symbol_us = dit_us,
+    .inter_char_us = 3u * dit_us,
+    .inter_word_us = 7u * dit_us,
   };
   return t;
+}
+
+void cw_apply_farnsworth(cw_timing_t* t, uint16_t element_wpm, uint16_t farnsworth_wpm) {
+  if (!t) return;
+
+  if (element_wpm < 5) element_wpm = 5;
+  if (element_wpm > 60) element_wpm = 60;
+
+  if (farnsworth_wpm == 0) farnsworth_wpm = element_wpm;
+  farnsworth_wpm = clamp_u16(farnsworth_wpm, 5, element_wpm);
+
+  // Crude but effective: scale only spacing by ratio element/farnsworth.
+  // When farnsworth_wpm < element_wpm => spacing gets longer.
+  // Keep an upper bound to avoid absurd long waits.
+  uint32_t ratio_x1000 = (uint32_t)element_wpm * 1000u / (uint32_t)farnsworth_wpm; // >= 1000
+  ratio_x1000 = clamp_u32(ratio_x1000, 1000u, 5000u);
+
+  t->inter_char_us = (t->inter_char_us * ratio_x1000) / 1000u;
+  t->inter_word_us = (t->inter_word_us * ratio_x1000) / 1000u;
+}
+
+void cw_apply_weight(cw_timing_t* t, uint16_t weight_pct) {
+  if (!t) return;
+
+  // Nominal is 50%. Clamp to a conservative range.
+  if (weight_pct == 0) weight_pct = 50;
+  weight_pct = clamp_u16(weight_pct, 35, 65);
+
+  // Scale key-down durations (dit/dah). Keep spacing as-is.
+  t->dit_us = (t->dit_us * (uint32_t)weight_pct) / 50u;
+  t->dah_us = (t->dah_us * (uint32_t)weight_pct) / 50u;
 }
 
 bool cw_is_word_gap(char c) {

--- a/firmware/pico_cw_keyer/src/cw_morse.h
+++ b/firmware/pico_cw_keyer/src/cw_morse.h
@@ -3,14 +3,24 @@
 #include <stdbool.h>
 
 typedef struct {
-  uint32_t dit_ms;
-  uint32_t dah_ms;
-  uint32_t intra_symbol_ms;
-  uint32_t inter_char_ms;
-  uint32_t inter_word_ms;
+  uint32_t dit_us;
+  uint32_t dah_us;
+  uint32_t intra_symbol_us;
+  uint32_t inter_char_us;
+  uint32_t inter_word_us;
 } cw_timing_t;
 
+// Element speed based on PARIS standard: dit length = 1200 / WPM ms
 cw_timing_t cw_timing_from_wpm(uint16_t wpm);
+
+// Apply Farnsworth spacing: keep dit/dah element speed from current timing,
+// but slow down inter-character and inter-word spacing using farnsworth_wpm.
+// If farnsworth_wpm == 0, it is treated as element_wpm.
+void cw_apply_farnsworth(cw_timing_t* t, uint16_t element_wpm, uint16_t farnsworth_wpm);
+
+// Apply keying weight in percent (50 = nominal). This scales dit/dah key-down duration.
+// Spacings are kept as-is (so extreme settings can affect effective speed).
+void cw_apply_weight(cw_timing_t* t, uint16_t weight_pct);
 
 // Returns pointer to a null-terminated pattern string consisting of '.' and '-'.
 // Returns NULL if unsupported character.

--- a/firmware/pico_cw_keyer/src/ioboard_regs.h
+++ b/firmware/pico_cw_keyer/src/ioboard_regs.h
@@ -4,15 +4,28 @@
 // CW Job register base
 #define CW_REG_BASE        200
 
+// --- Control/Status ---
 #define REG_CW_CMD         (CW_REG_BASE + 0)
 #define REG_CW_STATUS      (CW_REG_BASE + 1)
-#define REG_CW_WPM         (CW_REG_BASE + 2)
-#define REG_PTT_LEAD_MS    (CW_REG_BASE + 3)
-#define REG_PTT_TAIL_MS    (CW_REG_BASE + 4)
-#define REG_TEXT_LEN       (CW_REG_BASE + 5)
-#define REG_PROGRESS       (CW_REG_BASE + 6)
-#define REG_ERROR_CODE     (CW_REG_BASE + 7)
-#define REG_TEXT_BUF       (CW_REG_BASE + 8)
+
+// --- TX timing params ---
+#define REG_CW_WPM              (CW_REG_BASE + 2)
+#define REG_PTT_LEAD_MS         (CW_REG_BASE + 3)
+#define REG_PTT_TAIL_MS         (CW_REG_BASE + 4)
+#define REG_TEXT_LEN            (CW_REG_BASE + 5)
+#define REG_PROGRESS            (CW_REG_BASE + 6)
+#define REG_ERROR_CODE          (CW_REG_BASE + 7)
+
+// New parameters to improve CW TX quality (timing/spacing)
+// - Farnsworth WPM: slows down spacing (character/word gaps) while keeping element speed at REG_CW_WPM.
+//   If 0, firmware treats it as REG_CW_WPM.
+// - Weight percent: scales key-down time of dits/dahs. 50 = nominal.
+//   Valid range enforced in firmware.
+#define REG_FARNSWORTH_WPM      (CW_REG_BASE + 8)
+#define REG_WEIGHT_PCT          (CW_REG_BASE + 9)
+
+// Text buffer: 2 ASCII bytes per 16-bit register
+#define REG_TEXT_BUF            (CW_REG_BASE + 10)
 
 #define CW_STATUS_IDLE     0
 #define CW_STATUS_RUNNING  1

--- a/firmware/pico_cw_keyer/src/main.c
+++ b/firmware/pico_cw_keyer/src/main.c
@@ -41,9 +41,14 @@ static char text_get_char(uint16_t idx) {
   return (char)(word & 0xFF);
 }
 
-static void key_down(uint32_t ms) {
+static inline void sleep_us_exact(uint32_t us) {
+  // Avoid tight busy-wait loops. Use absolute time to reduce drift.
+  sleep_until(delayed_by_us(get_absolute_time(), (int64_t)us));
+}
+
+static void key_down_us(uint32_t us) {
   outputs_set_key(true);
-  sleep_ms(ms);
+  sleep_us_exact(us);
   outputs_set_key(false);
 }
 
@@ -57,10 +62,10 @@ static void send_char(char c, cw_timing_t t) {
 
   for (const char* p = pat; *p; ++p) {
     if (check_abort()) return;
-    if (*p == '.') key_down(t.dit_ms);
-    else if (*p == '-') key_down(t.dah_ms);
+    if (*p == '.') key_down_us(t.dit_us);
+    else if (*p == '-') key_down_us(t.dah_us);
     if (check_abort()) return;
-    sleep_ms(t.intra_symbol_ms);
+    sleep_us_exact(t.intra_symbol_us);
   }
 }
 
@@ -76,6 +81,8 @@ int main(void) {
   reg_write(REG_PTT_TAIL_MS, 120);
   reg_write(REG_TEXT_LEN, 0);
   reg_write(REG_PROGRESS, 0);
+  reg_write(REG_FARNSWORTH_WPM, 0); // 0 => same as REG_CW_WPM
+  reg_write(REG_WEIGHT_PCT, 50);    // 50 => nominal
 
   while (true) {
     uint16_t cmd = reg_read(REG_CW_CMD);
@@ -87,6 +94,9 @@ int main(void) {
 
     // Latch parameters
     uint16_t wpm = reg_read(REG_CW_WPM);
+    uint16_t farn = reg_read(REG_FARNSWORTH_WPM);
+    uint16_t weight = reg_read(REG_WEIGHT_PCT);
+
     uint16_t lead = reg_read(REG_PTT_LEAD_MS);
     uint16_t tail = reg_read(REG_PTT_TAIL_MS);
     uint16_t len  = reg_read(REG_TEXT_LEN);
@@ -98,6 +108,8 @@ int main(void) {
     }
 
     cw_timing_t timing = cw_timing_from_wpm(wpm);
+    cw_apply_farnsworth(&timing, wpm, farn);
+    cw_apply_weight(&timing, weight);
 
     reg_write(REG_PROGRESS, 0);
     set_status(CW_STATUS_RUNNING, 0);
@@ -114,10 +126,10 @@ int main(void) {
       if (c == 0) break;
 
       if (cw_is_word_gap(c)) {
-        sleep_ms(timing.inter_word_ms);
+        sleep_us_exact(timing.inter_word_us);
       } else {
         send_char(c, timing);
-        sleep_ms(timing.inter_char_ms);
+        sleep_us_exact(timing.inter_char_us);
       }
 
       reg_write(REG_PROGRESS, i + 1);

--- a/pi/backend/src/sota_cw/api.py
+++ b/pi/backend/src/sota_cw/api.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from .cw_jobs import CWJobManager
 from .cw_rx import CWDecoder
 from .hl2_control import HL2Control
@@ -17,7 +17,7 @@ cw_decoder = CWDecoder()
 
 # Bot Default Config
 default_bot_config = BotConfig(
-    my_call="NOCALL", # User must configure this
+    my_call="NOCALL",  # User must configure this
     my_ref="",
     wpm=20
 )
@@ -28,34 +28,56 @@ qso_bot = QSOBot(cw_manager, cw_decoder, default_bot_config)
 class CWSendRequest(BaseModel):
     text: str
     wpm: int = 20
-    # TX quality-related timing controls
+
+    # Optional: refine TX timing / readability
     ptt_lead_ms: int = 80
     ptt_tail_ms: int = 120
+
+    # Farnsworth spacing: slows down gaps while keeping element speed at wpm.
+    # 0 means "same as wpm".
+    farnsworth_wpm: int = Field(default=0, ge=0, le=60)
+
+    # Keying weight percent: 50 nominal.
+    weight_pct: int = Field(default=50, ge=0, le=100)
+
 
 class BotConfigRequest(BaseModel):
     my_call: str
     my_ref: str
     wpm: int
 
+
 @app.get("/health")
 def health():
     return {"status": "ok", "hl2": hl2.ip}
+
 
 # --- TX Routes ---
 
 @app.post("/cw/send")
 def send_cw(req: CWSendRequest):
-    job_id = cw_manager.start_job(req.text, req.wpm, req.ptt_lead_ms, req.ptt_tail_ms)
+    # CWJobManager already accepts a CWJob dataclass; keep API stable by mapping parameters here.
+    job_id = cw_manager.start_job(
+        req.text,
+        req.wpm,
+        ptt_lead_ms=req.ptt_lead_ms,
+        ptt_tail_ms=req.ptt_tail_ms,
+        farnsworth_wpm=req.farnsworth_wpm,
+        weight_pct=req.weight_pct,
+    )
     return {"job_id": job_id, "status": "started"}
+
 
 @app.post("/cw/abort")
 def abort_cw():
     cw_manager.abort_job()
     return {"status": "aborted"}
 
+
 @app.get("/cw/status")
 def get_status():
     return cw_manager.get_status()
+
 
 # --- RX Routes ---
 
@@ -65,11 +87,13 @@ def start_rx():
     cw_decoder.start()
     return {"status": "rx_started"}
 
+
 @app.post("/cw/rx/stop")
 def stop_rx():
     """Stoppt den Decoder"""
     cw_decoder.stop()
     return {"status": "rx_stopped"}
+
 
 @app.get("/cw/rx/text")
 def get_rx_text():
@@ -79,10 +103,12 @@ def get_rx_text():
         "running": cw_decoder.running
     }
 
+
 @app.post("/cw/rx/clear")
 def clear_rx_text():
     cw_decoder.clear_text()
     return {"status": "cleared"}
+
 
 # --- Bot Routes ---
 
@@ -93,17 +119,20 @@ def configure_bot(config: BotConfigRequest):
     qso_bot.config.wpm = config.wpm
     return {"status": "configured", "config": qso_bot.config}
 
+
 @app.post("/bot/start")
 def start_bot():
     """Starts the bot thread (IDLE state)"""
     qso_bot.start()
     return {"status": "bot_started"}
 
+
 @app.post("/bot/stop")
 def stop_bot():
     """Stops the bot thread"""
     qso_bot.stop()
     return {"status": "bot_stopped"}
+
 
 @app.post("/bot/cq")
 def trigger_cq():
@@ -112,6 +141,7 @@ def trigger_cq():
         raise HTTPException(status_code=400, detail="Bot not running. Call /bot/start first.")
     qso_bot.trigger_cq()
     return {"status": "cq_triggered"}
+
 
 @app.get("/bot/state")
 def get_bot_state():
@@ -129,6 +159,7 @@ def startup_event():
     cw_decoder.start()
     # Start Bot thread (IDLE)
     qso_bot.start()
+
 
 @app.on_event("shutdown")
 def shutdown_event():

--- a/pi/backend/src/sota_cw/cw_jobs.py
+++ b/pi/backend/src/sota_cw/cw_jobs.py
@@ -8,13 +8,17 @@ CW_CMD_IDLE = 0
 CW_CMD_START = 1
 CW_CMD_ABORT = 2
 
-
 @dataclass
 class CWJob:
     text: str
     wpm: int = 20
     ptt_lead_ms: int = 80
     ptt_tail_ms: int = 120
+    # TX quality / timing refinements
+    # Farnsworth spacing: if set (< wpm), increases inter-character/word gaps while keeping element speed.
+    farnsworth_wpm: int = 0
+    # Weighting: 50 = nominal; firmware clamps to a conservative range.
+    weight_pct: int = 50
 
 
 def _pack_two_chars(a: int, b: int) -> int:
@@ -34,8 +38,12 @@ def submit_job(io: IOBoard, job: CWJob) -> None:
     io.write_reg(base + 4, int(job.ptt_tail_ms))
     io.write_reg(base + 5, len(text))
 
+    # New TX quality params (see firmware register map)
+    io.write_reg(base + 8, int(job.farnsworth_wpm))
+    io.write_reg(base + 9, int(job.weight_pct))
+
     # Text buffer: 2 ASCII bytes per 16-bit register
-    buf_base = base + 8
+    buf_base = base + 10
     for i in range(0, len(text), 2):
         c0 = ord(text[i])
         c1 = ord(text[i + 1]) if (i + 1) < len(text) else 0
@@ -47,65 +55,3 @@ def submit_job(io: IOBoard, job: CWJob) -> None:
 
 def abort_job(io: IOBoard) -> None:
     io.write_reg(io.reg_base + 0, CW_CMD_ABORT)
-
-
-class CWJobManager:
-    """High-level TX job API used by FastAPI.
-
-    The backend stays state-light: the IO board is the authority for execution/state.
-    """
-
-    def __init__(self, io: IOBoard):
-        self.io = io
-        self._job_seq = 0
-        self._current_job_id: int | None = None
-
-    def start_job(
-        self,
-        text: str,
-        wpm: int = 20,
-        ptt_lead_ms: int = 80,
-        ptt_tail_ms: int = 120,
-    ) -> int:
-        self._job_seq += 1
-        job_id = self._job_seq
-
-        submit_job(
-            self.io,
-            CWJob(
-                text=text,
-                wpm=int(wpm),
-                ptt_lead_ms=int(ptt_lead_ms),
-                ptt_tail_ms=int(ptt_tail_ms),
-            ),
-        )
-
-        self._current_job_id = job_id
-        return job_id
-
-    def abort_job(self) -> None:
-        abort_job(self.io)
-
-    def get_status(self) -> dict:
-        # IO wiring might not be available in unit tests/dev without HL2 library.
-        try:
-            s = self.io.read_cw_status()
-        except NotImplementedError:
-            return {
-                "wired": False,
-                "job_id": self._current_job_id,
-                "error": "IOBoard read_reg/write_reg not wired (see third_party/README.md)",
-            }
-
-        return {
-            "wired": True,
-            "job_id": self._current_job_id,
-            "cmd": s.cmd,
-            "status": s.status,
-            "wpm": s.wpm,
-            "ptt_lead_ms": s.ptt_lead_ms,
-            "ptt_tail_ms": s.ptt_tail_ms,
-            "text_len": s.text_len,
-            "progress": s.progress,
-            "error_code": s.error_code,
-        }


### PR DESCRIPTION
## Motivation
Improve CW TX readability and stability by reducing drift/jitter in element timing and by adding operator-grade spacing/weighting controls.

## Changes
- Firmware (RP2040):
  - Move to µs-based waits for CW element/spacing timing.
  - Add Farnsworth spacing and keying weighting (register-controlled).
- Register map:
  - Add `REG_FARNSWORTH_WPM`, `REG_WEIGHT_PCT`.
  - Move `REG_TEXT_BUF` offset accordingly.
- Backend:
  - Extend `/cw/send` to accept `ptt_lead_ms`, `ptt_tail_ms`, `farnsworth_wpm`, `weight_pct`.
  - Write new params into the new registers.
- README:
  - Add Phase 4 “TX Quality” roadmap section and clarify envelope-shaping limitations.

## Notes
Envelope shaping / true key-click reduction requires HL2 TX amplitude shaping or external envelope hardware; this PR focuses on deterministic timing + spacing/weighting.
