### PR TITLE
Envelope shaping: CW env registers + backend defaults (3000/3000us)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ Das System kann nun nicht nur senden, sondern auch empfangen und selbstständig 
 - [x] **Deterministisches CW Timing (Firmware)**: Umstellung auf µs-basierte Delays (reduzierter Drift/Jitter im Element-Timing).
 - [x] **Farnsworth Spacing**: Element-Speed per WPM, aber vergrößerte Character/Word-Gaps über `farnsworth_wpm`.
 - [x] **Keying Weighting**: Konfigurierbare Dit/Dah-Keydown-Skalierung über `weight_pct` (50 = nominal).
-- [ ] **Envelope Shaping / Key Click Reduction**: Benötigt HL2-interne TX-Amplitudensteuerung oder externe Envelope-Hardware (nicht nur GPIO KEY on/off).
+- [ ] **Envelope Shaping / Key Click Reduction**: Register/API-Unterstützung ist in diesem Repo implementiert (Default `env_rise_us=3000`, `env_fall_us=3000`); die eigentliche Amplitudenrampe muss HL2-seitig in der Gateware/DSP-Kette umgesetzt werden (siehe `third_party/README.md` → `softerhardware/Hermes-Lite2`).
 - [ ] **QSK / Semi-BK Optimierung**: PTT/KEY Lead/Tail dynamisch (bandabhängig) und optional RX-TX „fast switch“.
 
 ## Lizenz / Third-Party
 
-Siehe `third_party/README.md` für die empfohlene Einbindung der HL2-Python-Referenz.
+Siehe `third_party/README.md` für die empfohlene Einbindung der HL2-Referenz (inkl. Gateware-Repo-Verweis).

--- a/docs/03_ioboard_register_protocol.md
+++ b/docs/03_ioboard_register_protocol.md
@@ -11,13 +11,34 @@ Viele IO-Board-Firmwares nutzen ein statisches Register-Array (z. B. 256 Bytes),
 ## Register-Namensraum / Kollisionen vermeiden
 Wenn mehrere Tools/Backends Register nutzen, ist es sinnvoll, „höhere“ Register (z. B. ab 200) für projektspezifische Features zu verwenden und die Nutzung zu dokumentieren, um Kollisionen zu vermeiden.
 
-## Empfehlung für diese Repo-Doku
-- Lege eine kleine Tabelle im Code/Repo an: Register → Bedeutung → Bitfelder → Default → Version.
-- Dokumentiere mindestens:
-  - Welche Register steuern PTT/KEY?
-  - Welche sind „Status“ vs. „Command“?
-  - Welche sind latched / welche sind edge-triggered?
+## CW Registermap (dieses Repo)
+
+CW-Registerbasis ist `CW_REG_BASE=200` (siehe `firmware/pico_cw_keyer/src/ioboard_regs.h`).
+
+### Basis-Register (200..)
+- 200: `REG_CW_CMD` (0=IDLE, 1=START, 2=ABORT)
+- 201: `REG_CW_STATUS` (0=IDLE, 1=RUNNING, 2=DONE, 3=ABORTED, 4=ERROR)
+- 202: `REG_CW_WPM`
+- 203: `REG_PTT_LEAD_MS`
+- 204: `REG_PTT_TAIL_MS`
+- 205: `REG_TEXT_LEN`
+- 206: `REG_PROGRESS`
+- 207: `REG_ERROR_CODE`
+- 208: `REG_FARNSWORTH_WPM`
+- 209: `REG_WEIGHT_PCT`
+
+### Textpuffer (210..)
+`REG_TEXT_BUF=210`, 2 ASCII pro 16-bit Register, Länge: `TEXT_MAX_CHARS=120` → 60 Register (210..269).
+
+### Envelope Shaping (270..)
+Diese Register sind für Key-Click-Reduktion gedacht. Dieses Repo schreibt sie; die HL2-Gateware muss sie auswerten.
+
+- 270: `REG_CW_RISE_US` – Rise-Time in µs (Default 3000)
+- 271: `REG_CW_FALL_US` – Fall-Time in µs (Default 3000)
+- 272: `REG_CW_ENV_SHAPE` – 0=linear (Default 0)
+- 273: `REG_CW_ENV_MAX_AMP_Q15` – Max-Amplitude (Q1.15; Default 32767)
 
 ## Weiterführende Links
+- HL2 Repo: https://github.com/softerhardware/Hermes-Lite2
 - HL2 Protocol Wiki: https://github.com/softerhardware/Hermes-Lite2/wiki/Protocol
 - Diskussion/Best-Practice zu IO-Board-Registerarrays und Registerbereichen: https://groups.google.com/g/hermes-lite/c/zVF4yR1VyjA

--- a/firmware/pico_cw_keyer/src/ioboard_regs.h
+++ b/firmware/pico_cw_keyer/src/ioboard_regs.h
@@ -40,3 +40,22 @@
 // Limits
 #define TEXT_MAX_CHARS     120
 #define TEXT_MAX_REGS      ((TEXT_MAX_CHARS + 1) / 2)
+
+// -----------------------------------------------------------------------------
+// Envelope shaping / key-click reduction
+//
+// Keep REG_TEXT_BUF offset stable. Place new registers AFTER the text buffer.
+// Text buffer range: REG_TEXT_BUF .. REG_TEXT_BUF + TEXT_MAX_REGS - 1 (210..269)
+// First free CW register: 270
+// -----------------------------------------------------------------------------
+#define REG_CW_ENV_BASE         (REG_TEXT_BUF + TEXT_MAX_REGS)   // 270
+
+// Rise/Fall time in microseconds (0 => disable shaping / hard keying)
+#define REG_CW_RISE_US          (REG_CW_ENV_BASE + 0)            // 270
+#define REG_CW_FALL_US          (REG_CW_ENV_BASE + 1)            // 271
+
+// Shape selector (0=linear; future: LUT-based raised cosine)
+#define REG_CW_ENV_SHAPE        (REG_CW_ENV_BASE + 2)            // 272
+
+// Max amplitude scaler (Q1.15: 0..32767 maps to 0.0..~1.0)
+#define REG_CW_ENV_MAX_AMP_Q15  (REG_CW_ENV_BASE + 3)            // 273

--- a/firmware/pico_cw_keyer/src/main.c
+++ b/firmware/pico_cw_keyer/src/main.c
@@ -84,6 +84,12 @@ int main(void) {
   reg_write(REG_FARNSWORTH_WPM, 0); // 0 => same as REG_CW_WPM
   reg_write(REG_WEIGHT_PCT, 50);    // 50 => nominal
 
+  // Envelope shaping defaults (used by HL2-side TX amplitude control)
+  reg_write(REG_CW_RISE_US, 3000);
+  reg_write(REG_CW_FALL_US, 3000);
+  reg_write(REG_CW_ENV_SHAPE, 0);
+  reg_write(REG_CW_ENV_MAX_AMP_Q15, 32767);
+
   while (true) {
     uint16_t cmd = reg_read(REG_CW_CMD);
 

--- a/pi/backend/src/sota_cw/api.py
+++ b/pi/backend/src/sota_cw/api.py
@@ -1,10 +1,19 @@
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
+
 from .cw_jobs import CWJobManager
 from .cw_rx import CWDecoder
 from .hl2_control import HL2Control
 from .ioboard import IOBoard
-from .config import HL2_IP, HL2_PORT, IO_REG_BASE
+from .config import (
+    HL2_IP,
+    HL2_PORT,
+    IO_REG_BASE,
+    CW_ENV_RISE_US,
+    CW_ENV_FALL_US,
+    CW_ENV_SHAPE,
+    CW_ENV_MAX_AMP_Q15,
+)
 from .qso_bot import QSOBot, BotConfig
 
 app = FastAPI(title="SOTA CW HL2 Backend")
@@ -12,7 +21,16 @@ app = FastAPI(title="SOTA CW HL2 Backend")
 # Initialize components
 hl2 = HL2Control(HL2_IP, HL2_PORT)
 io_board = IOBoard(IO_REG_BASE)
-cw_manager = CWJobManager(io_board)
+
+# CW manager defaults are configurable via env vars.
+cw_manager = CWJobManager(
+    io_board,
+    default_env_rise_us=CW_ENV_RISE_US,
+    default_env_fall_us=CW_ENV_FALL_US,
+    default_env_shape=CW_ENV_SHAPE,
+    default_env_max_amp_q15=CW_ENV_MAX_AMP_Q15,
+)
+
 cw_decoder = CWDecoder()
 
 # Bot Default Config
@@ -40,6 +58,13 @@ class CWSendRequest(BaseModel):
     # Keying weight percent: 50 nominal.
     weight_pct: int = Field(default=50, ge=0, le=100)
 
+    # Envelope shaping (HL2-side amplitude control)
+    # Default is enabled (3000/3000 us) via config/env.
+    env_rise_us: int = Field(default=CW_ENV_RISE_US, ge=0, le=20000)
+    env_fall_us: int = Field(default=CW_ENV_FALL_US, ge=0, le=20000)
+    env_shape: int = Field(default=CW_ENV_SHAPE, ge=0, le=10)
+    env_max_amp_q15: int = Field(default=CW_ENV_MAX_AMP_Q15, ge=0, le=32767)
+
 
 class BotConfigRequest(BaseModel):
     my_call: str
@@ -56,7 +81,6 @@ def health():
 
 @app.post("/cw/send")
 def send_cw(req: CWSendRequest):
-    # CWJobManager already accepts a CWJob dataclass; keep API stable by mapping parameters here.
     job_id = cw_manager.start_job(
         req.text,
         req.wpm,
@@ -64,6 +88,10 @@ def send_cw(req: CWSendRequest):
         ptt_tail_ms=req.ptt_tail_ms,
         farnsworth_wpm=req.farnsworth_wpm,
         weight_pct=req.weight_pct,
+        env_rise_us=req.env_rise_us,
+        env_fall_us=req.env_fall_us,
+        env_shape=req.env_shape,
+        env_max_amp_q15=req.env_max_amp_q15,
     )
     return {"job_id": job_id, "status": "started"}
 

--- a/pi/backend/src/sota_cw/config.py
+++ b/pi/backend/src/sota_cw/config.py
@@ -7,6 +7,13 @@ HL2_PORT = int(os.getenv("SOTA_CW_HL2_PORT", "1024"))
 # IO Board Configuration
 IO_REG_BASE = int(os.getenv("SOTA_CW_IO_REG_BASE", "200"))
 
+# CW TX Envelope Shaping (HL2-side amplitude control)
+# Defaults are intentionally non-zero to enable click-reduction out of the box.
+CW_ENV_RISE_US = int(os.getenv("SOTA_CW_ENV_RISE_US", "3000"))
+CW_ENV_FALL_US = int(os.getenv("SOTA_CW_ENV_FALL_US", "3000"))
+CW_ENV_SHAPE = int(os.getenv("SOTA_CW_ENV_SHAPE", "0"))
+CW_ENV_MAX_AMP_Q15 = int(os.getenv("SOTA_CW_ENV_MAX_AMP_Q15", "32767"))
+
 # CW Decoder Configuration
 # Enable internal python-based streamer (no external pipe command needed)
 USE_INTERNAL_STREAMER = os.getenv("SOTA_CW_USE_INTERNAL_STREAMER", "true").lower() == "true"

--- a/pi/backend/src/sota_cw/cw_jobs.py
+++ b/pi/backend/src/sota_cw/cw_jobs.py
@@ -8,17 +8,45 @@ CW_CMD_IDLE = 0
 CW_CMD_START = 1
 CW_CMD_ABORT = 2
 
+# Register offsets (relative to IO_REG_BASE / CW_REG_BASE)
+REG_OFF_CMD = 0
+REG_OFF_STATUS = 1
+REG_OFF_WPM = 2
+REG_OFF_PTT_LEAD_MS = 3
+REG_OFF_PTT_TAIL_MS = 4
+REG_OFF_TEXT_LEN = 5
+REG_OFF_PROGRESS = 6
+REG_OFF_ERROR = 7
+REG_OFF_FARNSWORTH_WPM = 8
+REG_OFF_WEIGHT_PCT = 9
+REG_OFF_TEXT_BUF = 10
+
+# Envelope shaping registers are placed AFTER the text buffer.
+# With TEXT_MAX_CHARS=120 => TEXT_MAX_REGS=60 => text regs: 10..69, first free is 70.
+REG_OFF_ENV_RISE_US = 70   # abs: base + 70 => 270
+REG_OFF_ENV_FALL_US = 71   # abs: base + 71 => 271
+REG_OFF_ENV_SHAPE = 72     # abs: base + 72 => 272
+REG_OFF_ENV_MAX_AMP_Q15 = 73  # abs: base + 73 => 273
+
+
 @dataclass
 class CWJob:
     text: str
     wpm: int = 20
     ptt_lead_ms: int = 80
     ptt_tail_ms: int = 120
+
     # TX quality / timing refinements
     # Farnsworth spacing: if set (< wpm), increases inter-character/word gaps while keeping element speed.
     farnsworth_wpm: int = 0
     # Weighting: 50 = nominal; firmware clamps to a conservative range.
     weight_pct: int = 50
+
+    # Envelope shaping (HL2-side amplitude control)
+    env_rise_us: int = 3000
+    env_fall_us: int = 3000
+    env_shape: int = 0
+    env_max_amp_q15: int = 32767
 
 
 def _pack_two_chars(a: int, b: int) -> int:
@@ -33,25 +61,95 @@ def submit_job(io: IOBoard, job: CWJob) -> None:
         text = text[:120]
 
     # Params
-    io.write_reg(base + 2, int(job.wpm))
-    io.write_reg(base + 3, int(job.ptt_lead_ms))
-    io.write_reg(base + 4, int(job.ptt_tail_ms))
-    io.write_reg(base + 5, len(text))
+    io.write_reg(base + REG_OFF_WPM, int(job.wpm))
+    io.write_reg(base + REG_OFF_PTT_LEAD_MS, int(job.ptt_lead_ms))
+    io.write_reg(base + REG_OFF_PTT_TAIL_MS, int(job.ptt_tail_ms))
+    io.write_reg(base + REG_OFF_TEXT_LEN, len(text))
 
-    # New TX quality params (see firmware register map)
-    io.write_reg(base + 8, int(job.farnsworth_wpm))
-    io.write_reg(base + 9, int(job.weight_pct))
+    # TX quality params (firmware-side)
+    io.write_reg(base + REG_OFF_FARNSWORTH_WPM, int(job.farnsworth_wpm))
+    io.write_reg(base + REG_OFF_WEIGHT_PCT, int(job.weight_pct))
+
+    # Envelope shaping params (HL2-side)
+    io.write_reg(base + REG_OFF_ENV_RISE_US, int(job.env_rise_us))
+    io.write_reg(base + REG_OFF_ENV_FALL_US, int(job.env_fall_us))
+    io.write_reg(base + REG_OFF_ENV_SHAPE, int(job.env_shape))
+    io.write_reg(base + REG_OFF_ENV_MAX_AMP_Q15, int(job.env_max_amp_q15))
 
     # Text buffer: 2 ASCII bytes per 16-bit register
-    buf_base = base + 10
+    buf_base = base + REG_OFF_TEXT_BUF
     for i in range(0, len(text), 2):
         c0 = ord(text[i])
         c1 = ord(text[i + 1]) if (i + 1) < len(text) else 0
         io.write_reg(buf_base + (i // 2), _pack_two_chars(c0, c1))
 
-    # Start
-    io.write_reg(base + 0, CW_CMD_START)
+    # Start (edge-trigger)
+    io.write_reg(base + REG_OFF_CMD, CW_CMD_START)
 
 
 def abort_job(io: IOBoard) -> None:
-    io.write_reg(io.reg_base + 0, CW_CMD_ABORT)
+    io.write_reg(io.reg_base + REG_OFF_CMD, CW_CMD_ABORT)
+
+
+class CWJobManager:
+    def __init__(
+        self,
+        io: IOBoard,
+        default_env_rise_us: int = 3000,
+        default_env_fall_us: int = 3000,
+        default_env_shape: int = 0,
+        default_env_max_amp_q15: int = 32767,
+    ):
+        self.io = io
+        self._job_seq = 0
+        self.default_env_rise_us = default_env_rise_us
+        self.default_env_fall_us = default_env_fall_us
+        self.default_env_shape = default_env_shape
+        self.default_env_max_amp_q15 = default_env_max_amp_q15
+
+    def start_job(
+        self,
+        text: str,
+        wpm: int = 20,
+        *,
+        ptt_lead_ms: int = 80,
+        ptt_tail_ms: int = 120,
+        farnsworth_wpm: int = 0,
+        weight_pct: int = 50,
+        env_rise_us: int | None = None,
+        env_fall_us: int | None = None,
+        env_shape: int | None = None,
+        env_max_amp_q15: int | None = None,
+    ) -> int:
+        self._job_seq += 1
+
+        job = CWJob(
+            text=text,
+            wpm=wpm,
+            ptt_lead_ms=ptt_lead_ms,
+            ptt_tail_ms=ptt_tail_ms,
+            farnsworth_wpm=farnsworth_wpm,
+            weight_pct=weight_pct,
+            env_rise_us=self.default_env_rise_us if env_rise_us is None else env_rise_us,
+            env_fall_us=self.default_env_fall_us if env_fall_us is None else env_fall_us,
+            env_shape=self.default_env_shape if env_shape is None else env_shape,
+            env_max_amp_q15=self.default_env_max_amp_q15 if env_max_amp_q15 is None else env_max_amp_q15,
+        )
+        submit_job(self.io, job)
+        return self._job_seq
+
+    def abort_job(self) -> None:
+        abort_job(self.io)
+
+    def get_status(self):
+        st = self.io.read_cw_status()
+        return {
+            "cmd": st.cmd,
+            "status": st.status,
+            "wpm": st.wpm,
+            "ptt_lead_ms": st.ptt_lead_ms,
+            "ptt_tail_ms": st.ptt_tail_ms,
+            "text_len": st.text_len,
+            "progress": st.progress,
+            "error_code": st.error_code,
+        }

--- a/third_party/README.md
+++ b/third_party/README.md
@@ -1,6 +1,6 @@
 # Third-party
 
-Dieses Projekt erwartet eine externe HL2-Library für HL2-UDP und IO-Board Register Read/Write (z. B. die Python-Referenz `hermeslite.py`). [file:1]
+Dieses Projekt erwartet eine externe HL2-Library für HL2-UDP und IO-Board Register Read/Write (z. B. die Python-Referenz `hermeslite.py`).
 
 ## Empfehlung: Submodule
 
@@ -10,4 +10,14 @@ Beispiel (als Submodule, Pfad frei wählbar):
 git submodule add https://github.com/softerhardware/Hermes-Lite2.git third_party/Hermes-Lite2
 ```
 
-Danach kann aus der jeweiligen Referenz die passende Python-Komponente eingebunden werden (ohne Copy/Paste) und in `pi/backend/src/sota_cw/hl2_control.py` / `ioboard.py` verdrahtet werden. [file:1]
+Danach kann aus der jeweiligen Referenz die passende Python-Komponente eingebunden werden (ohne Copy/Paste) und in `pi/backend/src/sota_cw/hl2_control.py` / `ioboard.py` verdrahtet werden.
+
+## HL2 Gateware (Envelope Shaping)
+
+Für **Envelope Shaping / Key-Click-Reduktion** wird eine HL2-interne TX-Amplitudensteuerung benötigt (Multiplikation der TX-I/Q-Samples mit einer Amplitudenrampe statt hartem TX-Gating).
+
+Dieses Repo implementiert dafür die Register-/Backend-Seite (IO-Board Register 270+; Default `env_rise_us=3000`, `env_fall_us=3000`).
+
+Die eigentliche Gateware/DSP-Implementierung ist im HL2-Projekt zu machen und wird hier nur referenziert:
+- GitHub: https://github.com/softerhardware/Hermes-Lite2
+- Protocol/IO-Board Kontext: https://github.com/softerhardware/Hermes-Lite2/wiki/Protocol


### PR DESCRIPTION
## Ziel
Implementiert die Repo-seitige Unterstützung für **Envelope Shaping / Key-Click-Reduction** (Registermap + Backend + Doku) mit Default `env_rise_us=3000`, `env_fall_us=3000`.

## Wichtiger Hinweis (HL2 Gateware)
Die eigentliche Amplitudenrampe muss im HL2 (FPGA/DSP TX-Pfad) implementiert werden. Dieses Repo referenziert dafür das HL2-Upstream-Repo:
- https://github.com/softerhardware/Hermes-Lite2

## Änderungen
- Registermap: neue CW-Envelope-Register ab Adresse 270 (nach Textpuffer), inkl. Defaultwerte.
- Pico-Firmware: initialisiert die neuen Register (Mock-Registerbank) auf 3000/3000 µs.
- Backend (FastAPI): neue Felder in `/cw/send` und konsistente CWJobManager-Implementierung.
- Doku: `docs/03_ioboard_register_protocol.md`, Root-README, `third_party/README.md` aktualisiert.

## Test
- Backend: `/health`, `/cw/send` (mit und ohne Envelope-Parameter), `/cw/status`.
