### PR TITLE
Docs: align envelope shaping with Hermes-Lite2_DSP PR#1

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ Das System kann nun nicht nur senden, sondern auch empfangen und selbstständig 
 - [ ] **SOTA CSV Export**: Download des Logs direkt über das Web-UI.
 - [ ] **Erweiterte Bot-Logik**: Umgang mit "QRL?", "QRS" und RBN-Spotting.
 
-### Phase 4: TX Quality (Neu)
+### Phase 4: TX Quality
 - [x] **Deterministisches CW Timing (Firmware)**: Umstellung auf µs-basierte Delays (reduzierter Drift/Jitter im Element-Timing).
 - [x] **Farnsworth Spacing**: Element-Speed per WPM, aber vergrößerte Character/Word-Gaps über `farnsworth_wpm`.
 - [x] **Keying Weighting**: Konfigurierbare Dit/Dah-Keydown-Skalierung über `weight_pct` (50 = nominal).
-- [ ] **Envelope Shaping / Key Click Reduction**: Register/API-Unterstützung ist in diesem Repo implementiert (Default `env_rise_us=3000`, `env_fall_us=3000`); die eigentliche Amplitudenrampe muss HL2-seitig in der Gateware/DSP-Kette umgesetzt werden (siehe `third_party/README.md` → `softerhardware/Hermes-Lite2`).
+- [x] **Envelope Shaping / Key Click Reduction**: Die Gateware/DSP-Implementierung ist in [philibertschlutzki/Hermes-Lite2_DSP](https://github.com/philibertschlutzki/Hermes-Lite2_DSP) umgesetzt (siehe PR #1 dort). Details zur Schnittstelle stehen in `third_party/README.md`.
 - [ ] **QSK / Semi-BK Optimierung**: PTT/KEY Lead/Tail dynamisch (bandabhängig) und optional RX-TX „fast switch“.
 
 ## Lizenz / Third-Party

--- a/third_party/README.md
+++ b/third_party/README.md
@@ -1,6 +1,6 @@
 # Third-party
 
-Dieses Projekt erwartet eine externe HL2-Library für HL2-UDP und IO-Board Register Read/Write (z. B. die Python-Referenz `hermeslite.py`).
+Dieses Projekt erwartet eine externe HL2-Library für HL2-UDP (IQ Stream) sowie Write/Read von Control/Command-Frames.
 
 ## Empfehlung: Submodule
 
@@ -14,10 +14,30 @@ Danach kann aus der jeweiligen Referenz die passende Python-Komponente eingebund
 
 ## HL2 Gateware (Envelope Shaping)
 
-Für **Envelope Shaping / Key-Click-Reduktion** wird eine HL2-interne TX-Amplitudensteuerung benötigt (Multiplikation der TX-I/Q-Samples mit einer Amplitudenrampe statt hartem TX-Gating).
+Für **Envelope Shaping / Key-Click-Reduktion** wird eine TX-Amplitudenrampe benötigt (Soft-Keying), d. h. die CW-TX-Amplitude wird nicht hart ge-gated, sondern per Rampe hoch/runter gefahren.
 
-Dieses Repo implementiert dafür die Register-/Backend-Seite (IO-Board Register 270+; Default `env_rise_us=3000`, `env_fall_us=3000`).
+### Implementierung (Gateware/DSP)
 
-Die eigentliche Gateware/DSP-Implementierung ist im HL2-Projekt zu machen und wird hier nur referenziert:
-- GitHub: https://github.com/softerhardware/Hermes-Lite2
-- Protocol/IO-Board Kontext: https://github.com/softerhardware/Hermes-Lite2/wiki/Protocol
+Die Gateware/DSP-Seite ist in diesem Fork umgesetzt:
+- Gateware/DSP Repo: [philibertschlutzki/Hermes-Lite2_DSP](https://github.com/philibertschlutzki/Hermes-Lite2_DSP)
+- PR: [CW envelope shaping: configurable rise/fall/max amplitude](https://github.com/philibertschlutzki/Hermes-Lite2_DSP/pull/1)
+
+### Schnittstelle (Control/Command)
+
+Die Parameter werden im FPGA im `radio`-Modul (`gateware/rtl/radio_openhpsdr1/radio.v`) über die bestehende Command-Schnittstelle gesetzt:
+
+- `cmd_addr = 0x18` (`ENV_CFG0`)
+  - `cmd_data[15:0]`  = `env_rise_us` (µs)
+  - `cmd_data[31:16]` = `env_fall_us` (µs)
+- `cmd_addr = 0x19` (`ENV_CFG1`)
+  - `cmd_data[15:0]`  = `env_max_amp_q15` (Q1.15; `0x7FFF` = 1.0)
+
+Defaults:
+- `env_rise_us=3000`
+- `env_fall_us=3000`
+- `env_max_amp_q15=0x7FFF`
+
+### Upstream-Kontext
+
+- Upstream HL2 Projekt: [softerhardware/Hermes-Lite2](https://github.com/softerhardware/Hermes-Lite2)
+- Protokoll/IO-Kontext: [Hermes-Lite2 Wiki / Protocol](https://github.com/softerhardware/Hermes-Lite2/wiki/Protocol)


### PR DESCRIPTION
Dokumentations-Update zur konsistenten Abstimmung mit der Gateware/DSP-Implementierung in `philibertschlutzki/Hermes-Lite2_DSP`.

Änderungen:
- `README.md`: Phase 4 (TX Quality) aktualisiert; Envelope Shaping als umgesetzt markiert und auf das DSP/Gateware Repo verwiesen.
- `third_party/README.md`: Referenz auf Gateware-Repo + PR #1 hinzugefügt und die **tatsächlich implementierte** Schnittstelle dokumentiert (`cmd_addr 0x18/0x19`, Defaults).

Abhängigkeit:
- Gateware PR: https://github.com/philibertschlutzki/Hermes-Lite2_DSP/pull/1