### PR TITLE
Backend: HL2 library integration (control + IO regs + CW envelope)

### DIFF
--- a/pi/backend/README.md
+++ b/pi/backend/README.md
@@ -1,9 +1,9 @@
 # Raspberry Pi Backend (FastAPI)
 
 Dieses Backend stellt eine kleine REST-API bereit, um:
-- HL2 Parameter (Frequenz/Mode) zu setzen (über eine HL2-Library, siehe `third_party/`).
+- HL2 Parameter (Frequenz/Envelope) über den **integrierten** HL2 UDP Client zu setzen.
 - CW-Jobs über das IO-Board Register-Protokoll zu starten/abzubrechen und Status zu lesen.
-- **NEU:** Headless IQ-Streamer & Decoder für den direkten Empfang ohne externe SDR-Software.
+- Headless IQ-Streamer & Decoder für den direkten Empfang ohne externe SDR-Software.
 
 ## Installation
 
@@ -14,35 +14,41 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
-**Hinweis**: Für den internen Streamer wird `numpy` benötigt (in requirements.txt enthalten).
-
 ## Konfiguration (Environment)
 
 Beispiele:
 ```bash
 export SOTA_CW_HL2_IP=192.168.1.50
 export SOTA_CW_HL2_PORT=1024
+export SOTA_CW_HL2_LOCAL_PORT=1025
 export SOTA_CW_IO_REG_BASE=200
+
+# Envelope Shaping defaults (optional)
+export SOTA_CW_ENV_RISE_US=3000
+export SOTA_CW_ENV_FALL_US=3000
+export SOTA_CW_ENV_MAX_AMP_Q15=32767
 ```
+
+Hinweis: `SOTA_CW_HL2_LOCAL_PORT` ist getrennt von 1024 gehalten, damit der Streamer weiterhin Port 1024 binden kann.
+
+## Envelope Shaping (HL2 Gateware)
+
+Das Backend setzt vor jedem CW-Job die HL2-Gateware-Parameter:
+- `cmd_addr=0x18`: Rise/Fall (µs)
+- `cmd_addr=0x19`: Max-Amplitude (Q1.15)
+
+Die Gateware/DSP-Seite dazu ist im Repo [philibertschlutzki/Hermes-Lite2_DSP](https://github.com/philibertschlutzki/Hermes-Lite2_DSP) umgesetzt.
 
 ## Nutzung des Headless Streamers
 
-Das Backend enthält nun ein Modul `hl2_stream`, das IQ-Daten direkt vom HL2 empfängt, demoduliert und ausgibt.
-
 **Testen (CW Audio hören):**
 ```bash
-# Gibt Audio (CW Sidetone) auf stdout aus -> aplay
 python -m sota_cw.hl2_stream --out - --demod cw --pitch 600 | aplay -r 48000 -f S16_LE -c 1
 ```
 
 **Verwendung mit multimon-ng (Decoder):**
 ```bash
 python -m sota_cw.hl2_stream --out - --demod cw --pitch 600 | multimon-ng -a MORSE_CW -t raw -
-```
-
-**IQ-Recording (Raw Data):**
-```bash
-python -m sota_cw.hl2_stream --out my_capture.iq
 ```
 
 ## Start der API

--- a/pi/backend/src/sota_cw/api.py
+++ b/pi/backend/src/sota_cw/api.py
@@ -3,11 +3,13 @@ from pydantic import BaseModel, Field
 
 from .cw_jobs import CWJobManager
 from .cw_rx import CWDecoder
+from .hl2_client import HL2Client
 from .hl2_control import HL2Control
 from .ioboard import IOBoard
 from .config import (
     HL2_IP,
     HL2_PORT,
+    HL2_LOCAL_PORT,
     IO_REG_BASE,
     CW_ENV_RISE_US,
     CW_ENV_FALL_US,
@@ -18,13 +20,15 @@ from .qso_bot import QSOBot, BotConfig
 
 app = FastAPI(title="SOTA CW HL2 Backend")
 
-# Initialize components
-hl2 = HL2Control(HL2_IP, HL2_PORT)
-io_board = IOBoard(IO_REG_BASE)
+# Initialize HL2 client + abstractions
+hl2_client = HL2Client(HL2_IP, HL2_PORT, local_port=HL2_LOCAL_PORT)
+hl2 = HL2Control(HL2_IP, HL2_PORT, client=hl2_client, local_port=HL2_LOCAL_PORT)
+io_board = IOBoard(hl2_client, IO_REG_BASE)
 
 # CW manager defaults are configurable via env vars.
 cw_manager = CWJobManager(
     io_board,
+    hl2=hl2,
     default_env_rise_us=CW_ENV_RISE_US,
     default_env_fall_us=CW_ENV_FALL_US,
     default_env_shape=CW_ENV_SHAPE,
@@ -47,19 +51,13 @@ class CWSendRequest(BaseModel):
     text: str
     wpm: int = 20
 
-    # Optional: refine TX timing / readability
     ptt_lead_ms: int = 80
     ptt_tail_ms: int = 120
 
-    # Farnsworth spacing: slows down gaps while keeping element speed at wpm.
-    # 0 means "same as wpm".
     farnsworth_wpm: int = Field(default=0, ge=0, le=60)
-
-    # Keying weight percent: 50 nominal.
     weight_pct: int = Field(default=50, ge=0, le=100)
 
     # Envelope shaping (HL2-side amplitude control)
-    # Default is enabled (3000/3000 us) via config/env.
     env_rise_us: int = Field(default=CW_ENV_RISE_US, ge=0, le=20000)
     env_fall_us: int = Field(default=CW_ENV_FALL_US, ge=0, le=20000)
     env_shape: int = Field(default=CW_ENV_SHAPE, ge=0, le=10)
@@ -111,24 +109,21 @@ def get_status():
 
 @app.post("/cw/rx/start")
 def start_rx():
-    """Startet den Hintergrundprozess für multimon-ng"""
     cw_decoder.start()
     return {"status": "rx_started"}
 
 
 @app.post("/cw/rx/stop")
 def stop_rx():
-    """Stoppt den Decoder"""
     cw_decoder.stop()
     return {"status": "rx_stopped"}
 
 
 @app.get("/cw/rx/text")
 def get_rx_text():
-    """Holt die letzten decodierten Textzeilen"""
     return {
         "lines": cw_decoder.get_text(),
-        "running": cw_decoder.running
+        "running": cw_decoder.running,
     }
 
 
@@ -150,21 +145,18 @@ def configure_bot(config: BotConfigRequest):
 
 @app.post("/bot/start")
 def start_bot():
-    """Starts the bot thread (IDLE state)"""
     qso_bot.start()
     return {"status": "bot_started"}
 
 
 @app.post("/bot/stop")
 def stop_bot():
-    """Stops the bot thread"""
     qso_bot.stop()
     return {"status": "bot_stopped"}
 
 
 @app.post("/bot/cq")
 def trigger_cq():
-    """Triggers the CQ sequence immediately"""
     if not qso_bot.running:
         raise HTTPException(status_code=400, detail="Bot not running. Call /bot/start first.")
     qso_bot.trigger_cq()
@@ -176,16 +168,24 @@ def get_bot_state():
     return {
         "state": qso_bot.state.name,
         "running": qso_bot.running,
-        "partner": qso_bot.current_partner_call
+        "partner": qso_bot.current_partner_call,
     }
 
 
 # Lifecycle
 @app.on_event("startup")
 def startup_event():
-    # Start RX by default for convenience
+    # Ensure HL2 is running (watchdog disabled for headless operation).
+    hl2.start(disable_watchdog=True)
+
+    # Program default envelope once at startup.
+    hl2.set_cw_envelope(
+        rise_us=CW_ENV_RISE_US,
+        fall_us=CW_ENV_FALL_US,
+        max_amp_q15=CW_ENV_MAX_AMP_Q15,
+    )
+
     cw_decoder.start()
-    # Start Bot thread (IDLE)
     qso_bot.start()
 
 

--- a/pi/backend/src/sota_cw/config.py
+++ b/pi/backend/src/sota_cw/config.py
@@ -4,6 +4,10 @@ import os
 HL2_IP = os.getenv("SOTA_CW_HL2_IP", "192.168.1.50")
 HL2_PORT = int(os.getenv("SOTA_CW_HL2_PORT", "1024"))
 
+# Local UDP port for HL2 control/requests.
+# 1025 is intentionally chosen so the streamer can still bind to 1024 if needed.
+HL2_LOCAL_PORT = int(os.getenv("SOTA_CW_HL2_LOCAL_PORT", "1025"))
+
 # IO Board Configuration
 IO_REG_BASE = int(os.getenv("SOTA_CW_IO_REG_BASE", "200"))
 

--- a/pi/backend/src/sota_cw/cw_jobs.py
+++ b/pi/backend/src/sota_cw/cw_jobs.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from .hl2_control import HL2Control
 from .ioboard import IOBoard
 
 CW_CMD_IDLE = 0
@@ -23,10 +24,10 @@ REG_OFF_TEXT_BUF = 10
 
 # Envelope shaping registers are placed AFTER the text buffer.
 # With TEXT_MAX_CHARS=120 => TEXT_MAX_REGS=60 => text regs: 10..69, first free is 70.
-REG_OFF_ENV_RISE_US = 70   # abs: base + 70 => 270
-REG_OFF_ENV_FALL_US = 71   # abs: base + 71 => 271
-REG_OFF_ENV_SHAPE = 72     # abs: base + 72 => 272
-REG_OFF_ENV_MAX_AMP_Q15 = 73  # abs: base + 73 => 273
+REG_OFF_ENV_RISE_US = 70
+REG_OFF_ENV_FALL_US = 71
+REG_OFF_ENV_SHAPE = 72
+REG_OFF_ENV_MAX_AMP_Q15 = 73
 
 
 @dataclass
@@ -37,9 +38,7 @@ class CWJob:
     ptt_tail_ms: int = 120
 
     # TX quality / timing refinements
-    # Farnsworth spacing: if set (< wpm), increases inter-character/word gaps while keeping element speed.
     farnsworth_wpm: int = 0
-    # Weighting: 50 = nominal; firmware clamps to a conservative range.
     weight_pct: int = 50
 
     # Envelope shaping (HL2-side amplitude control)
@@ -60,30 +59,26 @@ def submit_job(io: IOBoard, job: CWJob) -> None:
     if len(text) > 120:
         text = text[:120]
 
-    # Params
     io.write_reg(base + REG_OFF_WPM, int(job.wpm))
     io.write_reg(base + REG_OFF_PTT_LEAD_MS, int(job.ptt_lead_ms))
     io.write_reg(base + REG_OFF_PTT_TAIL_MS, int(job.ptt_tail_ms))
     io.write_reg(base + REG_OFF_TEXT_LEN, len(text))
 
-    # TX quality params (firmware-side)
     io.write_reg(base + REG_OFF_FARNSWORTH_WPM, int(job.farnsworth_wpm))
     io.write_reg(base + REG_OFF_WEIGHT_PCT, int(job.weight_pct))
 
-    # Envelope shaping params (HL2-side)
+    # Envelope shaping params (mirror into IO regs as well)
     io.write_reg(base + REG_OFF_ENV_RISE_US, int(job.env_rise_us))
     io.write_reg(base + REG_OFF_ENV_FALL_US, int(job.env_fall_us))
     io.write_reg(base + REG_OFF_ENV_SHAPE, int(job.env_shape))
     io.write_reg(base + REG_OFF_ENV_MAX_AMP_Q15, int(job.env_max_amp_q15))
 
-    # Text buffer: 2 ASCII bytes per 16-bit register
     buf_base = base + REG_OFF_TEXT_BUF
     for i in range(0, len(text), 2):
         c0 = ord(text[i])
         c1 = ord(text[i + 1]) if (i + 1) < len(text) else 0
         io.write_reg(buf_base + (i // 2), _pack_two_chars(c0, c1))
 
-    # Start (edge-trigger)
     io.write_reg(base + REG_OFF_CMD, CW_CMD_START)
 
 
@@ -95,12 +90,15 @@ class CWJobManager:
     def __init__(
         self,
         io: IOBoard,
+        *,
+        hl2: HL2Control | None = None,
         default_env_rise_us: int = 3000,
         default_env_fall_us: int = 3000,
         default_env_shape: int = 0,
         default_env_max_amp_q15: int = 32767,
     ):
         self.io = io
+        self.hl2 = hl2
         self._job_seq = 0
         self.default_env_rise_us = default_env_rise_us
         self.default_env_fall_us = default_env_fall_us
@@ -135,6 +133,15 @@ class CWJobManager:
             env_shape=self.default_env_shape if env_shape is None else env_shape,
             env_max_amp_q15=self.default_env_max_amp_q15 if env_max_amp_q15 is None else env_max_amp_q15,
         )
+
+        # Program HL2 gateware envelope before keying.
+        if self.hl2 is not None:
+            self.hl2.set_cw_envelope(
+                rise_us=job.env_rise_us,
+                fall_us=job.env_fall_us,
+                max_amp_q15=job.env_max_amp_q15,
+            )
+
         submit_job(self.io, job)
         return self._job_seq
 

--- a/pi/backend/src/sota_cw/hl2_client.py
+++ b/pi/backend/src/sota_cw/hl2_client.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import socket
+import struct
+import time
+from dataclasses import dataclass
+
+# Metis/HL2 protocol markers
+METIS_PORT_DEFAULT = 1024
+
+METIS_DISCOVERY = b"\xef\xfe\x02" + b"\x00" * 61
+METIS_START = b"\xef\xfe\x04"  # + <command byte> + 60x00
+METIS_STOP = b"\xef\xfe\x04"   # + <command byte> + 60x00
+
+
+@dataclass(frozen=True)
+class HL2Response:
+    addr: int
+    data: int
+    ptt: int
+
+
+class HL2Client:
+    """Minimaler HL2 UDP Client (Metis/openHPSDR kompatibler Kern).
+
+    Fokus:
+    - Senden von Command&Control Writes (C0..C4)
+    - Optionales RQST/ACK Roundtrip für Reads (ACK==1)
+    - Extended Address (EADDR) für "extended write" an ADDR 0x3f
+
+    Dieser Client ist absichtlich klein gehalten, um externe Abhängigkeiten
+    zu vermeiden und die Integration auf dem Raspberry Pi zu vereinfachen.
+    """
+
+    def __init__(
+        self,
+        hl2_ip: str,
+        hl2_port: int = METIS_PORT_DEFAULT,
+        *,
+        interface_ip: str = "0.0.0.0",
+        local_port: int = 1025,
+        timeout_s: float = 0.5,
+    ):
+        self.hl2_ip = hl2_ip
+        self.hl2_port = hl2_port
+
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.sock.bind((interface_ip, local_port))
+        self.sock.settimeout(timeout_s)
+
+        self._seq = 0
+
+    # --- Metis control ---
+
+    def metis_start(self, *, wideband: bool = False, disable_watchdog: bool = True) -> None:
+        cmd = 0
+        cmd |= 0x01  # start radio
+        if wideband:
+            cmd |= 0x02
+        if disable_watchdog:
+            cmd |= 0x80
+        pkt = METIS_START + bytes([cmd]) + b"\x00" * 60
+        self.sock.sendto(pkt, (self.hl2_ip, self.hl2_port))
+
+    def metis_stop(self, *, wideband: bool = False, disable_watchdog: bool = True) -> None:
+        cmd = 0
+        if wideband:
+            cmd |= 0x02
+        if disable_watchdog:
+            cmd |= 0x80
+        pkt = METIS_STOP + bytes([cmd]) + b"\x00" * 60
+        self.sock.sendto(pkt, (self.hl2_ip, self.hl2_port))
+
+    # --- Command & Control framing ---
+
+    def _build_cc_frame(self, *, addr: int, data: int, mox: bool, rqst: bool, eaddr: int = 0) -> bytes:
+        # C0: [7]=RQST, [6:1]=ADDR[5:0], [0]=MOX
+        c0 = ((1 if rqst else 0) << 7) | ((addr & 0x3F) << 1) | (1 if mox else 0)
+
+        payload = bytearray(1024)
+        payload[0] = c0
+        payload[1:5] = struct.pack(">I", data & 0xFFFFFFFF)
+
+        # HL2: Extended address word directly after DATA word.
+        # Word format: [31:24] reserved, [15:0] EADDR
+        payload[5:9] = struct.pack(">I", eaddr & 0xFFFF)
+
+        header = b"\xef\xfe\x01" + bytes([0x02]) + struct.pack(">I", self._seq & 0xFFFFFFFF)
+        self._seq = (self._seq + 1) & 0xFFFFFFFF
+
+        return header + payload
+
+    def _recv_ack(self, *, expect_addr: int, timeout_s: float = 0.6) -> HL2Response:
+        deadline = time.time() + timeout_s
+        while time.time() < deadline:
+            try:
+                pkt, _ = self.sock.recvfrom(2048)
+            except socket.timeout:
+                continue
+
+            if not pkt.startswith(b"\xef\xfe\x01") or len(pkt) < 8 + 5:
+                continue
+
+            payload = pkt[8:]
+            c0 = payload[0]
+
+            # ACK==1 response
+            if (c0 & 0x80) == 0:
+                continue
+
+            raddr = (c0 >> 1) & 0x3F
+            ptt = c0 & 0x01
+            rdata = struct.unpack(">I", payload[1:5])[0]
+
+            if raddr != (expect_addr & 0x3F):
+                continue
+
+            return HL2Response(addr=raddr, data=rdata, ptt=ptt)
+
+        raise TimeoutError(f"HL2 ACK timeout for ADDR=0x{expect_addr:02x}")
+
+    def cc_write(self, *, addr: int, data: int, mox: bool = False, rqst: bool = False, eaddr: int = 0) -> HL2Response | None:
+        frame = self._build_cc_frame(addr=addr, data=data, mox=mox, rqst=rqst, eaddr=eaddr)
+        self.sock.sendto(frame, (self.hl2_ip, self.hl2_port))
+        if rqst:
+            return self._recv_ack(expect_addr=addr)
+        return None
+
+    # --- Convenience: Extended registers via ADDR 0x3f + EADDR ---
+
+    def ext_write_u16(self, *, eaddr: int, value: int) -> None:
+        self.cc_write(addr=0x3F, data=value & 0xFFFF, rqst=False, eaddr=eaddr)
+
+    def ext_read_u16(self, *, eaddr: int) -> int:
+        resp = self.cc_write(addr=0x3F, data=0, rqst=True, eaddr=eaddr)
+        if resp is None:
+            raise RuntimeError("Missing response")
+        return resp.data & 0xFFFF

--- a/pi/backend/src/sota_cw/hl2_control.py
+++ b/pi/backend/src/sota_cw/hl2_control.py
@@ -1,20 +1,42 @@
 from __future__ import annotations
 
-class HL2Control:
-    """Abstraktion für HL2 Control (Frequenz/Mode).
+from .hl2_client import HL2Client
 
-    In dieser Repo-Version ist das bewusst ein Skeleton. Empfohlen ist die
-    Einbindung einer bestehenden HL2-Python-Referenz (z. B. `hermeslite.py`).
+
+class HL2Control:
+    """HL2 Control (Frequenz/Envelope).
+
+    Diese Implementierung nutzt den Metis/openHPSDR kompatiblen Command&Control Kern
+    (siehe `HL2Client`) und stellt die für dieses Repo benötigten Operationen bereit.
+
+    Ein "Mode" (CW/USB/LSB) ist auf HL2-Seite primär Host/DSP-Konvention und wird
+    hier nur als Host-State gespeichert.
     """
 
-    def __init__(self, ip: str, port: int):
+    def __init__(self, ip: str, port: int, *, client: HL2Client | None = None, local_port: int = 1025):
         self.ip = ip
         self.port = port
+        self.client = client or HL2Client(ip, port, local_port=local_port)
+        self._mode = "CWU"
+
+    def start(self, *, disable_watchdog: bool = True) -> None:
+        self.client.metis_start(disable_watchdog=disable_watchdog)
+
+    def stop(self, *, disable_watchdog: bool = True) -> None:
+        self.client.metis_stop(disable_watchdog=disable_watchdog)
 
     def set_frequency_hz(self, hz: int) -> None:
-        # TODO: implement via HL2 UDP protocol / 3rd party library
-        raise NotImplementedError("HL2 frequency control not wired yet. See third_party/README.md")
+        # Set TX and RX1 NCOs (ADDR 0x01 and 0x02).
+        self.client.cc_write(addr=0x01, data=int(hz) & 0xFFFFFFFF)
+        self.client.cc_write(addr=0x02, data=int(hz) & 0xFFFFFFFF)
 
     def set_mode(self, mode: str) -> None:
-        # TODO: implement via HL2 UDP protocol / 3rd party library
-        raise NotImplementedError("HL2 mode control not wired yet. See third_party/README.md")
+        self._mode = mode
+
+    def set_cw_envelope(self, *, rise_us: int, fall_us: int, max_amp_q15: int) -> None:
+        # Gateware interface (Hermes-Lite2_DSP PR#1):
+        # 0x18: [15:0]=rise_us, [31:16]=fall_us
+        # 0x19: [15:0]=max_amp_q15
+        d0 = ((int(fall_us) & 0xFFFF) << 16) | (int(rise_us) & 0xFFFF)
+        self.client.cc_write(addr=0x18, data=d0)
+        self.client.cc_write(addr=0x19, data=int(max_amp_q15) & 0xFFFF)

--- a/pi/backend/src/sota_cw/ioboard.py
+++ b/pi/backend/src/sota_cw/ioboard.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from .hl2_client import HL2Client
+
+
 @dataclass
 class CWStatus:
     cmd: int
@@ -13,21 +16,27 @@ class CWStatus:
     progress: int
     error_code: int
 
+
 class IOBoard:
     """Register-I/O Abstraktion.
 
-    Erwartet read_reg/write_reg (16-bit). In der Praxis wird das über die HL2
-    IO-Board Read/Write Funktionen einer HL2-Library realisiert.
+    Dieses Projekt nutzt ein Registermodell (16-bit) im Adressbereich ab `reg_base`.
+
+    Implementiert via HL2 Command&Control "Extended Address":
+    - ADDR 0x3f + EADDR (Register-Adresse)
+
+    Damit sind Registeradressen > 255 möglich (Textbuffer + Envelope-Regs).
     """
 
-    def __init__(self, reg_base: int = 200):
+    def __init__(self, hl2: HL2Client, reg_base: int = 200):
+        self.hl2 = hl2
         self.reg_base = reg_base
 
     def read_reg(self, addr: int) -> int:
-        raise NotImplementedError("IOBoard read_reg not wired yet. See third_party/README.md")
+        return int(self.hl2.ext_read_u16(eaddr=int(addr)))
 
     def write_reg(self, addr: int, value: int) -> None:
-        raise NotImplementedError("IOBoard write_reg not wired yet. See third_party/README.md")
+        self.hl2.ext_write_u16(eaddr=int(addr), value=int(value))
 
     def read_cw_status(self) -> CWStatus:
         base = self.reg_base


### PR DESCRIPTION
Implementiert die konkrete HL2-Library-Integration (ohne externe Dependencies) für Control/Command-Frames und IO-Board Registerzugriff.

Änderungen:
- Neues Modul `pi/backend/src/sota_cw/hl2_client.py`: Metis/openHPSDR Command&Control (C0..C4), optional RQST/ACK, Extended Address (EADDR) über ADDR 0x3f.
- `hl2_control.py`: echte Implementierung für Frequenz (ADDR 0x01/0x02) und CW-Envelope (cmd_addr 0x18/0x19).
- `ioboard.py`: `read_reg/write_reg` via EADDR, damit Register >255 (Textbuffer/Envelope) funktionieren.
- `cw_jobs.py`: setzt Envelope vor jedem Job über HL2Control.
- `api.py`: verdrahtet HL2Client/HL2Control/IOBoard; programmiert Default-Envelope beim Startup.
- `config.py` + `pi/backend/README.md`: Dokumentation/Env-Var `SOTA_CW_HL2_LOCAL_PORT` und Envelope-Shaping.

Abhängigkeit (Gateware):
- Envelope Register-Interface: https://github.com/philibertschlutzki/Hermes-Lite2_DSP/pull/1